### PR TITLE
Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Image Source: [MPU6050 | Live Graph | Raspberry Pi](https://sparkfun.hackster.io
 
 ## Installation
 
-0. **Install IMU Tools
+0. **Install IMU Tools:**
+You must install IMU tools, please visit their repo for instructions
 
-https://github.com/CCNYRoboticsLab/imu_tools
+[https://github.com/CCNYRoboticsLab/imu_tools](https://github.com/CCNYRoboticsLab/imu_tools)
 
 1. **Clone the Repository:**
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ Image Source: [MPU6050 | Live Graph | Raspberry Pi](https://sparkfun.hackster.io
 
 ## Installation
 
-0. **Install IMU Tools:**
-You must install IMU tools, please visit their repo for instructions
-
-[https://github.com/CCNYRoboticsLab/imu_tools](https://github.com/CCNYRoboticsLab/imu_tools)
-
 1. **Clone the Repository:**
 
 Navigate to your catkin workspace's `src` directory and clone the repository:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Image Source: [MPU6050 | Live Graph | Raspberry Pi](https://sparkfun.hackster.io
 
 ## Installation
 
+0. **Install IMU Tools
+
+https://github.com/CCNYRoboticsLab/imu_tools
+
 1. **Clone the Repository:**
 
 Navigate to your catkin workspace's `src` directory and clone the repository:

--- a/scripts/imu_publisher
+++ b/scripts/imu_publisher
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 
+
 import rospy
 
 from mpu6050_dmp_ros.MPU6050 import MPU6050
@@ -10,22 +11,24 @@ if __name__ == "__main__":
     rospy.init_node("imu_publisher")
 
     # TODO: create a simple procedure to calculate and recopilate the offset values (copy/paste-able)
-    topic_name = rospy.get_param('~topic_name', 'imu_data')
-    frame_id = rospy.get_param('~frame_id', 'base_link')
-    i2c_bus = rospy.get_param('~i2c_bus', 1)
-    device_address = rospy.get_param('~device_address', 0x68)
-    x_accel_offset = rospy.get_param('~x_accel_offset', 0)
-    y_accel_offset = rospy.get_param('~y_accel_offset', 0)
-    z_accel_offset = rospy.get_param('~z_accel_offset', 0)
-    x_gyro_offset = rospy.get_param('~x_gyro_offset', 0)
-    y_gyro_offset = rospy.get_param('~y_gyro_offset', 0)
-    z_gyro_offset = rospy.get_param('~z_gyro_offset', 0)
+    topic_name = rospy.get_param('~/imu_publisher/topic_name', 'imu_data')
+    frame_id = rospy.get_param('~/imu_publisher/frame_id', 'base_link')
+    i2c_bus = rospy.get_param('~/imu_publisher/i2c_bus', 1)
+    device_address = rospy.get_param('~/imu_publisher/device_address', 0x68)
+    x_accel_offset = rospy.get_param('~/imu_publisher/x_accel_offset', 0)
+    y_accel_offset = rospy.get_param('~/imu_publisher/y_accel_offset', 0)
+    z_accel_offset = rospy.get_param('~/imu_publisher/z_accel_offset', 0)
+    x_gyro_offset = rospy.get_param('~/imu_publisher/x_gyro_offset', 0)
+    y_gyro_offset = rospy.get_param('~/imu_publisher/y_gyro_offset', 0)
+    z_gyro_offset = rospy.get_param('~/imu_publisher/z_gyro_offset', 0)
 
     pub = rospy.Publisher(topic_name, Imu, queue_size=10)
     rate = rospy.Rate(10)
 
+    print(f"mpu = MPU6050(i2c_bus={i2c_bus}, device_address={device_address}, x_accel_offset={x_accel_offset}, y_accel_offset={y_accel_offset}, z_accel_offset={z_accel_offset}, x_gyro_offset={x_gyro_offset}, y_gyro_offset={y_gyro_offset}, z_gyro_offset={z_gyro_offset}, False)")
     mpu = MPU6050(i2c_bus, device_address, x_accel_offset, y_accel_offset,
                   z_accel_offset, x_gyro_offset, y_gyro_offset, z_gyro_offset, False)
+    
 
     mpu.dmp_initialize()
     mpu.set_DMP_enabled(True)
@@ -35,6 +38,7 @@ if __name__ == "__main__":
     FIFO_count = mpu.get_FIFO_count()
 
     FIFO_buffer = [0]*64
+
 
     try:
         while not rospy.is_shutdown():

--- a/scripts/imu_publisher
+++ b/scripts/imu_publisher
@@ -25,7 +25,6 @@ if __name__ == "__main__":
     pub = rospy.Publisher(topic_name, Imu, queue_size=10)
     rate = rospy.Rate(10)
 
-    print(f"mpu = MPU6050(i2c_bus={i2c_bus}, device_address={device_address}, x_accel_offset={x_accel_offset}, y_accel_offset={y_accel_offset}, z_accel_offset={z_accel_offset}, x_gyro_offset={x_gyro_offset}, y_gyro_offset={y_gyro_offset}, z_gyro_offset={z_gyro_offset}, False)")
     mpu = MPU6050(i2c_bus, device_address, x_accel_offset, y_accel_offset,
                   z_accel_offset, x_gyro_offset, y_gyro_offset, z_gyro_offset, False)
     


### PR DESCRIPTION
This command fails if you do not have IMU tools for ROS installed
'rosdep install --from-paths src --ignore-src -r -y'

I updated the readme with the link to their repo

Also updated 

    topic_name = rospy.get_param('~/imu_publisher/topic_name', 'imu_data')
    frame_id = rospy.get_param('~/imu_publisher/frame_id', 'base_link')
    i2c_bus = rospy.get_param('~/imu_publisher/i2c_bus', 1)
    device_address = rospy.get_param('~/imu_publisher/device_address', 0x68)
    x_accel_offset = rospy.get_param('~/imu_publisher/x_accel_offset', 0)
    y_accel_offset = rospy.get_param('~/imu_publisher/y_accel_offset', 0)
    z_accel_offset = rospy.get_param('~/imu_publisher/z_accel_offset', 0)
    x_gyro_offset = rospy.get_param('~/imu_publisher/x_gyro_offset', 0)
    y_gyro_offset = rospy.get_param('~/imu_publisher/y_gyro_offset', 0)
    z_gyro_offset = rospy.get_param('~/imu_publisher/z_gyro_offset', 0)

the '/imu_publisher/' were missing and default values were being used 
